### PR TITLE
Update cassaforte dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,5 +4,5 @@
   :url "https://github.com/sprin/cassaforte-meter-transmission-gen"
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [clj-time "0.5.1"]
-                 [clojurewerkz/cassaforte "1.0.0-rc6-SNAPSHOT"]]
+                 [clojurewerkz/cassaforte "1.0.1"]]
   :main cassaforte-test.core)


### PR DESCRIPTION
Problems you've experienced with compile are because of a tiny bit outdated cassaforte version, it's fixed in latest one!
